### PR TITLE
fix: apm-tool update

### DIFF
--- a/packages/ownable-multi/README.md
+++ b/packages/ownable-multi/README.md
@@ -55,8 +55,8 @@ Downlad the package into your project as a single lua file:
 
 ```shell
 cd your/project/directory
-apm-tool download ownable-multi
-cp apm_modules/@autonomousfinance/ownable-multi/main.lua ./ownable-multi.lua
+apm download @autonomousfinance/ownable-multi
+cp apm_modules/@autonomousfinance/ownable-multi/source.lua ./ownable-multi.lua
 ```
 
 Require the file locally from your main process file. 

--- a/packages/ownable/README.md
+++ b/packages/ownable/README.md
@@ -55,8 +55,8 @@ Downlad the package into your project as a single lua file:
 
 ```shell
 cd your/project/directory
-apm-tool download ownable
-cp apm_modules/@autonomousfinance/ownable/main.lua ./ownable.lua
+apm download @autonomousfinance/ownable
+cp apm_modules/@autonomousfinance/ownable/source.lua ./ownable.lua
 ```
 
 Require the file locally from your main process file. 

--- a/packages/subscribable/README.md
+++ b/packages/subscribable/README.md
@@ -44,14 +44,14 @@ Downlad the package into your project as a single lua file:
 
 ```shell
 cd your/project/directory
-apm-tool download ownable-multi
-cp apm_modules/@autonomousfinance/ownable-multi/main.lua ./ownable-multi.lua
+apm download @autonomousfinance/subscribable
+cp apm_modules/@autonomousfinance/subscribable/source.lua ./subscribable.lua
 ```
 
 Require the file locally from your main process lua file. 
 
 ```lua
-Ownable = require("subscribable") ({
+Subscribable = require("subscribable") ({
   useDB = false -- using the vanilla flavour
 })
 ```


### PR DESCRIPTION
- APM Tool has been updated and now requires `apm download [packagename]` instead of `apm-tool download [packagename]`
- the package-name format is also changed to `@vendor/package@version` from `package`
- the code file is renamed to `source.lua` from `main.lua` in `apm_modules`